### PR TITLE
feat: Implement dynamic chat theme based on message keywords

### DIFF
--- a/onecomity-frontend/screens/ChatScreen.js
+++ b/onecomity-frontend/screens/ChatScreen.js
@@ -7,11 +7,15 @@ import api, { getChatMessages } from '../services/api';
 const SOCKET_URL = 'http://192.168.2.34:5000'; // Your backend Socket.IO URL
 
 // Helper for bubble color by activity
-const getBubbleColor = (activity) => {
+const getBubbleColor = (messageText, activity) => {
+  const lowerCaseText = messageText ? messageText.toLowerCase() : '';
+  if (lowerCaseText.includes('weed')) return '#b1e5c6'; // green
+  if (lowerCaseText.includes('wine')) return '#ffb3b3'; // red
+  // Fallback to activity prop if no keyword found
   if (activity === 'weed') return '#b1e5c6';
   if (activity === 'wine') return '#ffb3b3';
   if (activity === 'water') return '#b3d1ff';
-  return '#daf1ff'; // fallback (for 'my' messages or unknown)
+  return '#daf1ff'; // fallback (for 'my' messages or unknown activity)
 };
 
 export default function ChatScreen({ route }) {
@@ -20,6 +24,50 @@ export default function ChatScreen({ route }) {
   const [messages, setMessages] = useState([]);
   const [text, setText] = useState('');
   const socketRef = useRef(null);
+  const [chatBackgroundColor, setChatBackgroundColor] = useState('#ffffff'); // Default background
+  const [inputConfig, setInputConfig] = useState({
+    rowBgColor: '#ffffff',
+    inputBorderColor: '#ccc',
+    rowBorderTopColor: '#eee',
+  });
+
+  // Helper to get theme color based on activity
+  const getActivityColor = (detectedActivity) => {
+    if (detectedActivity === 'weed') return '#e6ffe6'; // light green background
+    if (detectedActivity === 'wine') return '#ffe6e6'; // light red background
+    return '#ffffff'; // default white background
+  };
+
+  // Helper to get colors for input area
+  const getInputColors = (detectedActivity) => {
+    if (detectedActivity === 'weed') {
+      return {
+        rowBgColor: '#e6ffe6', // light green
+        inputBorderColor: '#77dd77', // medium green
+        rowBorderTopColor: '#c1e5c1', // slightly darker green
+      };
+    }
+    if (detectedActivity === 'wine') {
+      return {
+        rowBgColor: '#ffe6e6', // light red
+        inputBorderColor: '#ff8a80', // medium red
+        rowBorderTopColor: '#e5c1c1', // slightly darker red
+      };
+    }
+    return {
+      rowBgColor: '#ffffff', // default white
+      inputBorderColor: '#ccc', // default gray
+      rowBorderTopColor: '#eee', // default light gray
+    };
+  };
+
+  // Helper to detect activity from message text
+  const detectActivityFromMessage = (messageText) => {
+    const lowerCaseText = messageText ? messageText.toLowerCase() : '';
+    if (lowerCaseText.includes('weed')) return 'weed';
+    if (lowerCaseText.includes('wine')) return 'wine';
+    return null;
+  };
 
   // 1. Get my own userId from storage (must be set at login)
   useEffect(() => {
@@ -37,9 +85,28 @@ export default function ChatScreen({ route }) {
       try {
         if (!userId) return;
         const res = await getChatMessages(userId);
-        setMessages(res.data.messages || []);
+        const loadedMessages = res.data.messages || [];
+        setMessages(loadedMessages);
         // Log for debugging
-        console.log('💬 Chat history loaded:', res.data.messages?.length ?? 0);
+        console.log('💬 Chat history loaded:', loadedMessages.length ?? 0);
+
+        // Set initial background and input colors based on chat history
+        let activityDetected = false;
+        for (let i = loadedMessages.length - 1; i >= 0; i--) {
+          const detectedActivity = detectActivityFromMessage(loadedMessages[i].text);
+          if (detectedActivity) {
+            const newChatBgColor = getActivityColor(detectedActivity);
+            setChatBackgroundColor(newChatBgColor);
+            setInputConfig(getInputColors(detectedActivity));
+            activityDetected = true;
+            break;
+          }
+        }
+        if (!activityDetected) {
+          // Reset to default if no keywords in history
+          setChatBackgroundColor(getActivityColor(null));
+          setInputConfig(getInputColors(null));
+        }
       } catch (err) {
         console.log('❌ Failed to load chat history', err);
       }
@@ -62,6 +129,15 @@ export default function ChatScreen({ route }) {
       ) {
         setMessages((prev) => [...prev, msg]);
         console.log('💬 New real-time message:', msg.text);
+        // Update background and input colors based on new message
+        const detectedActivity = detectActivityFromMessage(msg.text);
+        if (detectedActivity) { // This ensures it only updates if keywords are present
+          const newChatBgColor = getActivityColor(detectedActivity);
+          setChatBackgroundColor(newChatBgColor);
+          setInputConfig(getInputColors(detectedActivity));
+        }
+        // If the new message does NOT contain a keyword, we don't revert the color.
+        // The color should persist from the last keyword message.
       }
     });
 
@@ -91,11 +167,13 @@ export default function ChatScreen({ route }) {
   // 5. Render messages (oldest at top, newest at bottom)
   const renderItem = ({ item }) => {
     const isMine = item.sender === myId;
+    const bubbleColor = getBubbleColor(item.text, activity); // Get color based on text and activity
+
     return (
       <View style={[
         styles.messageBubble,
         isMine ? styles.myMessage : styles.otherMessage,
-        !isMine && { backgroundColor: getBubbleColor(activity) } // Only for other user's messages
+        { backgroundColor: bubbleColor } // Apply color to all bubbles
       ]}>
         <Text style={styles.msgText}>{item.text}</Text>
         <Text style={styles.msgMeta}>
@@ -107,18 +185,27 @@ export default function ChatScreen({ route }) {
 
   return (
     <KeyboardAvoidingView
-      style={styles.container}
+      style={[styles.container, { backgroundColor: chatBackgroundColor }]}
       behavior={Platform.select({ ios: 'padding', android: undefined })}
     >
       <FlatList
         data={messages} // natural order: oldest to newest
         renderItem={renderItem}
         keyExtractor={(item, idx) => item._id || String(idx)}
-        contentContainerStyle={{ padding: 16, paddingBottom: 90 }}
+        contentContainerStyle={{ padding: 16, paddingBottom: 90 }} // Ensure paddingBottom is enough for inputRow
       />
-      <View style={styles.inputRow}>
+      <View style={[
+        styles.inputRow,
+        { 
+          backgroundColor: inputConfig.rowBgColor,
+          borderTopColor: inputConfig.rowBorderTopColor,
+        }
+      ]}>
         <TextInput
-          style={styles.input}
+          style={[
+            styles.input,
+            { borderColor: inputConfig.inputBorderColor, backgroundColor: '#ffffff' } // Explicit white background
+          ]}
           placeholder="Type a message..."
           value={text}
           onChangeText={setText}
@@ -133,15 +220,15 @@ export default function ChatScreen({ route }) {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: '#fff' },
+  container: { flex: 1 }, // backgroundColor will be dynamic
   messageBubble: {
     marginVertical: 4,
     padding: 10,
     borderRadius: 10,
     maxWidth: '80%',
   },
-  myMessage: { backgroundColor: '#daf1ff', alignSelf: 'flex-end' },
-  otherMessage: { alignSelf: 'flex-start' },
+  myMessage: { alignSelf: 'flex-end' }, // backgroundColor will be set by getBubbleColor
+  otherMessage: { alignSelf: 'flex-start' }, // backgroundColor will be set by getBubbleColor
   msgText: { fontSize: 16 },
   msgMeta: { fontSize: 11, color: '#888', marginTop: 3 },
   inputRow: {
@@ -149,12 +236,20 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     padding: 12,
     borderTopWidth: 1,
-    borderColor: '#eee',
-    backgroundColor: '#fff',
-    position: 'absolute',
+    // borderColor is now dynamic (inputConfig.rowBorderTopColor)
+    // backgroundColor is now dynamic (inputConfig.rowBgColor)
+    position: 'absolute', // Keep it at the bottom
     bottom: 0, left: 0, right: 0,
   },
-  input: { flex: 1, padding: 12, borderWidth: 1, borderColor: '#ccc', borderRadius: 20, marginRight: 10 },
+  input: { 
+    flex: 1, 
+    padding: 12, 
+    borderWidth: 1, 
+    // borderColor is now dynamic (inputConfig.inputBorderColor)
+    borderRadius: 20, 
+    marginRight: 10,
+    // backgroundColor is now dynamic (explicitly #ffffff in JSX)
+  },
   sendBtn: { backgroundColor: '#1e90ff', paddingHorizontal: 22, paddingVertical: 10, borderRadius: 18 },
   sendBtnText: { color: '#fff', fontWeight: 'bold', fontSize: 16 },
 });


### PR DESCRIPTION
This commit introduces a dynamic theming feature to the chat screen. The chat bubbles, chat screen background, and chat input area now change color based on keywords ("weed" for green theme, "wine" for red theme) detected in the messages.

Key changes:
- Modified `ChatScreen.js` to include logic for detecting keywords in messages (case-insensitive).
- Implemented state variables and helper functions to manage and apply dynamic colors for:
    - Individual message bubbles
    - Overall chat screen background
    - Chat input row background and input field border
- Ensured that the theme changes are triggered by both incoming real-time messages and by scanning the chat history upon loading.
- The theme persists based on the latest message containing a keyword.
- If no keywords are present, default colors or colors based on the navigation `activity` prop (for bubbles) are used.
- Verified text contrast and UI element visibility with the new dynamic colors.